### PR TITLE
Add Algolia secrets to build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
 
       - name: Install dependencies & build
         run: npm ci && npm run build
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
 
       # Popular action to deploy to GitHub Pages:
       # https://docusaurus.io/docs/deployment#deploying-to-github-pages


### PR DESCRIPTION
## What are you changing in this pull request and why?

<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here!

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->

Free [Algolia Docsearch](https://docsearch.algolia.com/) has been approved. APP ID, secret and index name are added in the Github project secrets. During the build step, docusaurus can compile these secrets. 

<img width="753" alt="image" src="https://user-images.githubusercontent.com/1352979/235693311-23f3a904-a3e3-439d-9945-f249a1303671.png">