### PR TITLE
fix: add missing glue permission

### DIFF
--- a/docs/docs/getting-started/prerequisites/iam-permissions.md
+++ b/docs/docs/getting-started/prerequisites/iam-permissions.md
@@ -24,6 +24,7 @@ dbt-athena uses the AWS Glue API to fetch metadata. You will need to set these p
 "glue:GetDatabases",
 "glue:GetTable",
 "glue:GetTables",
+"glue:GetTableVersions",
 "glue:GetPartition",
 "glue:GetPartitions",
 ```


### PR DESCRIPTION
## What are you changing in this pull request and why?

<!---
Describe your changes and why you're making them. If linked to an open
issue or a pull request on dbt Core, then link to them here!

To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).
-->
dbt-athena fetches Glue table versions [here](https://github.com/dbt-athena/dbt-athena/blob/74a74f0790489cbbb8d9ab629a80f8c607a679d7/dbt/adapters/athena/impl.py#L884). We ran into an error because we were missing the right IAM permission. 


## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.
- [x] Add a checklist item for anything that needs to happen before this PR is merged, such as "needs technical review" or "change base branch."

Adding new pages (delete if not applicable):

- [ ] Add page to `sidebars.js`
- [ ] Provide a unique filename for the new page

Removing or renaming existing pages (delete if not applicable):

- [ ] Remove page from `sidebars.js`
- [ ] Add an entry `static/_redirects`
