### PR TITLE
fix: add `athena:GetDataCatalog`

### DIFF
--- a/docs/docs/getting-started/prerequisites/iam-permissions.md
+++ b/docs/docs/getting-started/prerequisites/iam-permissions.md
@@ -13,6 +13,7 @@ Athena permissions that are required to run queries:
 "athena:GetWorkGroup",
 "athena:StopQueryExecution",
 "athena:GetQueryExecution",
+"athena:GetDataCatalog",
 ```
 
 ## Glue IAM permissions


### PR DESCRIPTION
Seems that this is needed by DBT to do its work.

## What are you changing in this pull request and why?

Ran into this permissions issue running in DBT Cloud: the iam user needed `athena:GetDataCatalog` -- specifically it needs to access the AwsDataCatalog to do itse work.

## Checklist

- [x] Review the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) and [About versioning](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) so my content adheres to these guidelines.